### PR TITLE
:fire: The Join Our Discord page is no longer needed.

### DIFF
--- a/src/routes/discord.svelte
+++ b/src/routes/discord.svelte
@@ -1,7 +1,0 @@
-<svelte:head>
-    <title>Discord</title>
-</svelte:head>
-
-<h1>Join our Discord!</h1>
-
-<p>Simply click <a href="https://discordapp.com/invite/HPK3hB6">here</a>!</p>


### PR DESCRIPTION
Removed the `Join Our Discord` page as we no longer need it. (The navbar directly links to a server invite).