### PR TITLE
Fixed partner logos not appearing!

### DIFF
--- a/src/routes/partners.svelte
+++ b/src/routes/partners.svelte
@@ -9,7 +9,7 @@
     <div class="card border-0 shadow-lg mb-3">
       <div class="card-body">
         <div class="media">
-          <a href="https://file.coffee"><img alt="file.coffee Logo" src="https://cdn.discordapp.com/icons/526109287328645120/0860fa512f188a578a5b7b365094aab5.png" class="mr-3 w-10 rounded" draggable="false"></a>
+          <a href="https://file.coffee"><img alt="file.coffee Logo" src="https://file.coffee/QGUrNODuz.png" class="mr-3 w-10 rounded" draggable="false"></a>
           <div class="media-body">
             <h5 class="card-title"><b><a href="https://file.coffee">file.coffee</a></b></h5>
             <p class="card-text">Love to Share files that are larger than 8MB via Discord or need it for a project? Or make a lot of screenshots but also love privacy? Then try out file.coffee, it's the anonymous file sharing service. No accounts, no registration, just "plug and play".</p>
@@ -20,7 +20,7 @@
     <div class="card border-0 shadow-lg mb-3">
       <div class="card-body">
         <div class="media">
-          <a href="https://points.city"><img alt="Points Logo" src="https://cdn.discordapp.com/icons/532985647011463189/67ee2ea584a8bd5c4e5129ed66c1f44d.png" class="mr-3 w-10 rounded" draggable="false"></a>
+          <a href="https://points.city"><img alt="Points Logo" src="https://points.city/images/logo/Discord.png" class="mr-3 w-10 rounded" draggable="false"></a>
           <div class="media-body">
             <h5 class="card-title"><b><a href="https://points.city">Points</a></b></h5>
             <p class="card-text">Points is a clean yet very customizable points bot that features an simple and modern dashboard. Points adds one of the most intuitive yet customizable economy style experiences to any server.</p>
@@ -31,7 +31,7 @@
     <div class="card border-0 shadow-lg">
       <div class="card-body">
         <div class="media">
-          <a href="https://crystalbotlist.uk"><img alt="CrystalBotList Logo" src="https://cdn.discordapp.com/icons/597531758657011743/7a845a27934c8d1ac89b266fef39aff2.png" class="mr-3 w-10 rounded" draggable="false"></a>
+          <a href="https://crystalbotlist.uk"><img alt="CrystalBotList Logo" src="https://file.coffee/OZ5vZd6xF.png" class="mr-3 w-10 rounded" draggable="false"></a>
           <div class="media-body">
             <h5 class="card-title"><b><a href="https://crystalbotlist.uk">Crystal Bot List</a></b></h5>
             <p class="card-text">Crystal Bot List is a growing directory of Discord bots to enhance your server with bot creators adding their newly designed bot constantly, this allows users from all over the world to browse and add the desired bot to their own server with a click of a button without any hassle or 'know how'.</p>


### PR DESCRIPTION
Links were old and invalid, the links were from the Discord CDN so when the server icon was changed the old one was deleted.