### PR TITLE
Fixed Discord Invite

### DIFF
--- a/src/routes/discord.js
+++ b/src/routes/discord.js
@@ -1,5 +1,5 @@
 export function get (req, res) {
-    let url = 'https://discordapp.com/invite/HPK3hB6';
+    let url = 'https://discord.gg/UqjGnc3';
     res.writeHead(302, {
         Location: url
     });


### PR DESCRIPTION
The old Discord invite was invalid and has been updated.

Old Invite (Invalid): https://discord.gg/HPK3hB6
New Invite (Valid): https://discord.gg/UqjGnc3

This PR is a fix for issue #52 